### PR TITLE
Update install for pikepdf==9.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node-modules
 node_modules
 .DS_Store
 __pycache__
+scrapy.log
+.idea

--- a/pdfCheck.py
+++ b/pdfCheck.py
@@ -1,4 +1,4 @@
-from pikepdf import Pdf, String, _qpdf
+from pikepdf import Pdf, String
 import pikepdf
 from pikepdf.models.metadata import decode_pdf_date
 from datetime import datetime
@@ -321,11 +321,11 @@ def checkFile(fileName: str, site: str = None, debug: bool = False):
 
         result['EmptyTextTest'] = 'Fail' if (len(res['fontNames']) == 0 or res['numTxt'] == 0) else 'Pass'
 
-    except _qpdf.PdfError as err:
+    except pikepdf.qpdf.PdfError as err:
         result['BrokenFile'] = True
         result['Accessible'] = None
         result['_log'] += 'PdfError: {0}'.format(err)
-    except _qpdf.PasswordError as err:
+    except pikepdf.qpdf.PasswordError as err:
         result['BrokenFile'] = True
         result['Accessible'] = None
         result['_log'] += 'Password protected file: {0}'.format(err)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scrapy
-pikepdf==6.2.9
+pikepdf==9.5.2
 langcodes
 pdfminer.six
 bitstring


### PR DESCRIPTION
This PR makes 3 changes:

* Uses pikepdf 9.5.2, the latest release
* Replaces _qpdf references with pikepdf.qpdf
* Fixes missing entries in .gitignore.