### PR TITLE
Update dependencies and fix bug in crawl.sh 

### DIFF
--- a/crawl.sh
+++ b/crawl.sh
@@ -6,5 +6,4 @@ gnutimeout() {
         timeout "$@"
     fi
 }
-cat list-sites.txt | while read i; do echo $i; mkdir -p crawled_files/$i ; gnutimeout -s KILL 4h scrapy runspider --logfile=scrapy.log pdf_spider.py -a url=https://$i; done
-
+cat list-sites.txt | while read i || [ -n "$i" ]; do echo "$i"; mkdir -p "crawled_files/$i" ; gnutimeout -s KILL 4h scrapy runspider --logfile=scrapy.log pdf_spider.py -a url="https://$i"; done

--- a/docAnalysis.js
+++ b/docAnalysis.js
@@ -1,4 +1,4 @@
-const parse = require('csv-parse/lib/sync')
+const { parse } = require('csv-parse/sync')
 const fs = require('fs')
 const pdfCheck = parse(fs.readFileSync('./out/pdfCheck.csv'), {
     columns: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,21 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "csv-parse": "^4.16.3"
+        "csv-parse": "^6.2.1"
       }
     },
     "node_modules/csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
     }
   },
   "dependencies": {
     "csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/accessibility-luxembourg/pdfCrawler.git"
+    "url": "git+https://github.com/accessibility-luxembourg/simplA11yPDFCrawler.git"
   },
   "author": "SIP",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/accessibility-luxembourg/pdfCrawler/issues"
+    "url": "https://github.com/accessibility-luxembourg/simplA11yPDFCrawler/issues"
   },
-  "homepage": "https://github.com/accessibility-luxembourg/pdfCrawler#readme"
+  "homepage": "https://github.com/accessibility-luxembourg/simplA11yPDFCrawler?tab=readme-ov-file#simpla11ypdfcrawler"
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "csv-parse": "^4.16.3"
+    "csv-parse": "^6.2.1"
   },
   "repository": {
     "type": "git",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scrapy
-pikepdf==9.5.2
+pikepdf~=10.5
 langcodes
 pdfminer.six
 bitstring


### PR DESCRIPTION
## Summary

This PR does 4 things:

- Updates `pikepdf` (currently does not install properly on my M2 MacBook)
- Updates `csv-parse` to latest (works fine, but it is behind)
- Fix a small bug in `crawl.sh`
- Update links in package.json to point at this repo

### Details 

#### Fix a small bug in `crawl.sh`

So I created a `list-sites.txt` file and added one url to it, and then it wasn't doing anything. 

The reason ended up being that the `read` command doesn't return success unless there is a newline, even though it does set `$i`.

So now it does this: `read i || [ -n "$i" ]`, which is like "if `read` worked or there is a variable in `$`.